### PR TITLE
Changed link inside comment on schema.graphql file

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,4 +1,4 @@
-# To really understand GraphQL, go to http://graphql.org/guide/
+# To really understand GraphQL, go to https://graphql.org/learn/
 
 type Book {
   authors: [String!]


### PR DESCRIPTION
The link to the graphql documentation on a comment on the `./graphql/schema,graphql` file is outdateded. This PR fixes that.

 - Old link http://graphql.org/guide/
 - Correct Link https://graphql.org/learn/
 